### PR TITLE
fix: reload window on error

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,13 +2,17 @@
 <html>
   <head>
     <script>
+      const onerrorBackup = window.onerror;
+
       window.onerror = function(msg, url, line, col, error) {
           if (error.constructor.name === "DOMException" && error.message.startsWith("Failed to execute 'replaceState'")) {
               // This is a chrome bug. See https://github.com/hotwired/turbo/issues/536
               // Solution is to navigate to the same page again but without the basic auth credentials.
               window.location.href = window.location.href + " ";
+          } else {
+              onerror && onerrorBackup(msg, url, line, col, error);
           }
-      }
+      };
     </script>
 
     <title>TurboTodos</title>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <script>
+      window.onerror = function(msg, url, line, col, error) {
+          if (error.constructor.name === "DOMException" && error.message.startsWith("Failed to execute 'replaceState'")) {
+              // This is a chrome bug. See https://github.com/hotwired/turbo/issues/536
+              window.location.reload();
+          }
+      }
+    </script>
+
     <title>TurboTodos</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,8 @@
       window.onerror = function(msg, url, line, col, error) {
           if (error.constructor.name === "DOMException" && error.message.startsWith("Failed to execute 'replaceState'")) {
               // This is a chrome bug. See https://github.com/hotwired/turbo/issues/536
-              window.location.reload();
+              // Solution is to navigate to the same page again but without the basic auth credentials.
+              window.location.href = window.location.href + " ";
           }
       }
     </script>


### PR DESCRIPTION
Demonstrates how to reload the window, when the chrome bug triggers. It's important to have this in the HTML file, because the error is thrown before the application.js is executed.